### PR TITLE
Do not include the ansel library as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Install FastGedcom using pip from [its PyPI page](https://pypi.org/project/fastg
 ```bash
 pip install fastgedcom
 ```
+To install the Ansel codecs use the following command. It enables the use of the Ansel text encoding often used for gedcom files.
+```bash
+pip install fastgedcom[ansel]
+```
 
 ## Why choosing FastGedcom?
 

--- a/fastgedcom/parser.py
+++ b/fastgedcom/parser.py
@@ -8,11 +8,15 @@ from typing import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-import ansel  # type: ignore[import-untyped]
+try:
+    import ansel  # type: ignore[import-untyped]
+except ImportError as e:
+    IS_ANSEL_INSTALLED = False
+else:
+    IS_ANSEL_INSTALLED = True
+    ansel.register()
 
 from .base import Document, TrueLine, XRef
-
-ansel.register()
 
 
 class ParsingError(Exception):
@@ -163,10 +167,12 @@ def guess_encoding(file: str | Path) -> str | None:
     # Try non-utf encodings and loog at the 0 HEAD > 1 CHAR gedcom field
     encodings = (
         "utf-8",
-        "ansel",
+        "ansel" if IS_ANSEL_INSTALLED else None,
         "iso8859-1",
     )
     for encoding in encodings:
+        if encoding is None:
+            continue
         try:
             with open(file, "r", encoding=encoding) as f:
                 for line in f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
 	"Topic :: Sociology :: Genealogy",
 	"Intended Audience :: Developers",
 	"Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 license = {text = "MIT License"}
 requires-python = ">=3.10"
 dependencies = [
-	"ansel>=1.0.0",
 ]
 classifiers = [
 	"License :: OSI Approved :: MIT License",
@@ -37,6 +36,9 @@ dev = [
 	"twine",
 	"sphinx-rtd-theme",
 	"sphinx-autoapi",
+]
+ansel = [
+	"ansel>=1.0.0",
 ]
 
 [build-system]

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -7,9 +7,9 @@ from sys import platform
 from fastgedcom.base import TrueLine
 from fastgedcom.helpers import get_all_sub_lines
 from fastgedcom.parser import (
-    CharacterInsteadOfLineWarning, DuplicateXRefWarning, EmptyLineWarning,
-    LevelInconsistencyWarning, LevelParsingWarning, LineParsingWarning,
-    guess_encoding, parse
+    IS_ANSEL_INSTALLED, CharacterInsteadOfLineWarning, DuplicateXRefWarning,
+    EmptyLineWarning, LevelInconsistencyWarning, LevelParsingWarning,
+    LineParsingWarning, guess_encoding, parse
 )
 
 file_utf8 = Path(__file__).parent / "test_data" / "in_utf8.ged"
@@ -55,11 +55,12 @@ class TestParser(unittest.TestCase):
         with open(file_unicode, "r", encoding="utf-16") as f:
             self._test_parsing(f, 27)
 
-    @unittest.skipUnless(platform.startswith("win"), "requires Windows")
+    @unittest.skipUnless(platform.startswith("win"), "The ansi encoding is only available on Windows")
     def test_parsing_ansi(self) -> None:
         with open(file_ansi, "r", encoding="ansi") as f:
             self._test_parsing(f, 27)
 
+    @unittest.skipUnless(IS_ANSEL_INSTALLED, "The ansel package isn't installed")
     def test_parsing_ansel(self) -> None:
         with open(file_ansel, "r", encoding="gedcom") as f:
             g, w = parse(f)


### PR DESCRIPTION
The inclusion of the ansel library (used for the gedcom codec only) should be "opt-in", not the default.