### PR TITLE
Add get_source methods to Line and Document

### DIFF
--- a/examples/document_statistics.py
+++ b/examples/document_statistics.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from fastgedcom.base import Document, TrueLine
-from fastgedcom.helpers import get_all_sub_lines
 from fastgedcom.parser import strict_parse
 
 document = strict_parse("../my_gedcom.ged")
@@ -27,7 +26,7 @@ print("Number of families:", nb_records_per_type["FAM"])
 if nb_records_per_type["INDI"] != 0:
     total_nb_lines_indi = 0
     for indi in document >> "INDI":
-        total_nb_lines_indi += sum(1 for _ in get_all_sub_lines(indi))
+        total_nb_lines_indi += sum(1 for _ in indi.get_all_sub_lines())
     print("Average number of lines per INDI record:",
           total_nb_lines_indi / nb_records_per_type["INDI"])
 

--- a/examples/export_to_gedcom.py
+++ b/examples/export_to_gedcom.py
@@ -1,8 +1,6 @@
-from fastgedcom.base import Document
-from fastgedcom.helpers import get_source
 from fastgedcom.parser import parse
 
-file_pathname = "../my_new_gedcom.ged"
+file_pathname = "./my_new_gedcom.ged"
 
 minimal_gedcom_text = """0 HEAD
 1 GEDC
@@ -11,20 +9,10 @@ minimal_gedcom_text = """0 HEAD
 1 CHAR UTF-8
 0 TRLR
 """
+
 minimal_gedcom, _ = parse(minimal_gedcom_text.splitlines())
 
-
-def save(document: Document) -> str:
-    text = ""
-    for record in document:
-        record_gedcom = get_source(record)
-        text += record_gedcom
-    return text
-
-
-gedcom_to_save = save(minimal_gedcom)
-
-assert (gedcom_to_save == minimal_gedcom_text)
+gedcom_to_save = minimal_gedcom.get_source()
 
 # Gedcom standards recommends the UTF-8 with BOM encoding for new gedcom.
 with open(file_pathname, "w", encoding="utf-8-sig") as f:

--- a/examples/information_on_family.py
+++ b/examples/information_on_family.py
@@ -1,5 +1,5 @@
 from fastgedcom.helpers import (
-    extract_name_parts, extract_year, format_date, format_name, get_source
+    extract_name_parts, extract_year, format_date, format_name
 )
 from fastgedcom.parser import strict_parse
 
@@ -55,12 +55,3 @@ if family > "DIV":
 
 for event in family >> "EVEN":
     print("Event:", event >= 'TYPE')
-
-
-###############################################################################
-# Raw gedcom information
-###############################################################################
-
-
-print("Original gedcom data:")
-print(get_source(family))

--- a/fastgedcom/base.py
+++ b/fastgedcom/base.py
@@ -58,6 +58,11 @@ class Line(ABC):
         """The content of this gedcom field, namely the payload combined
         with all CONT and CONC sub-lines."""
 
+    @property
+    @abstractmethod
+    def sub_lines(self) -> list['TrueLine']:
+        """See the description of :py:class:`.TrueLine` class."""
+
     @abstractmethod
     def get_sub_lines(self, tag: str) -> list['TrueLine']:
         """Return all sub-lines having the given :any:`tag`.
@@ -88,6 +93,25 @@ class Line(ABC):
         by using the >= operator."""
         return self.get_sub_line_payload(tag)
 
+    def get_all_sub_lines(self) -> Iterator['TrueLine']:
+        """Recursively iterate on sub-lines.
+        All lines under the given line are returned. The order is preserved
+        as in the gedcom file, sub-sub-lines come before siblings lines."""
+        lines = list(self.sub_lines)
+        while len(lines) > 0:
+            line = lines.pop(0)
+            yield line
+            lines = line.sub_lines + lines
+
+    def get_source(self) -> str:
+        """Return the gedcom text equivalent for the line and its sub-lines."""
+        if not self:
+            return ""
+        text = str(self) + "\n"
+        for sub_line in self.get_all_sub_lines():
+            text += str(sub_line) + "\n"
+        return text
+
 
 class FakeLine(Line):
     """Dummy line for syntactic sugar.
@@ -105,7 +129,7 @@ class FakeLine(Line):
 
     payload = ""  # pyright: ignore[reportGeneralTypeIssues]
     payload_with_cont = ""  # pyright: ignore[reportGeneralTypeIssues]
-    sub_lines: list['TrueLine'] = []
+    sub_lines = []  # pyright: ignore[reportGeneralTypeIssues]
 
     def __bool__(self) -> Literal[False]:
         """Return False."""

--- a/fastgedcom/base.py
+++ b/fastgedcom/base.py
@@ -97,7 +97,7 @@ class Line(ABC):
         """Recursively iterate on sub-lines.
         All lines under the given line are returned. The order is preserved
         as in the gedcom file, sub-sub-lines come before siblings lines."""
-        lines = list(self.sub_lines)
+        lines = self.sub_lines.copy()
         while len(lines) > 0:
             line = lines.pop(0)
             yield line
@@ -295,6 +295,11 @@ class Document():
         if not isinstance(__value, Document):
             return False
         return self.records == __value.records
+
+    def get_source(self) -> str:
+        """Return the gedcom text equivalent for the :py:class:`.Document` into a string.
+        Usefull to save a modified :py:class:`.Document` into a file."""
+        return "".join(record.get_source() for record in self.records.values())
 
 
 fake_line = FakeLine()

--- a/fastgedcom/helpers.py
+++ b/fastgedcom/helpers.py
@@ -1,5 +1,5 @@
 """Utilitary functions to sort, format, or extract information."""
-
+import warnings
 from typing import Iterator, overload
 from datetime import datetime, time
 from enum import Enum
@@ -8,24 +8,23 @@ from .base import FakeLine, TrueLine
 
 
 def get_all_sub_lines(line: TrueLine) -> Iterator[TrueLine]:
-    """Recursively iterate on :py:class:`.TrueLine` of higher level.
+    """/!\\ DEPRECATED /!\\ use the method :py:meth:`Line.get_all_sub_lines` instead.
+
+    Recursively iterate on :py:class:`.TrueLine` of higher level.
     All lines under the given line are returned. The order is preserved
     as in the gedcom file, sub-lines come before siblings lines."""
-    lines = list(line.sub_lines)
-    while len(lines) > 0:
-        line = lines.pop(0)
-        yield line
-        lines = line.sub_lines + lines
+    warnings.warn("Use the Line.get_all_sub_lines method instead of function in fastgedcom.helpers",
+                  DeprecationWarning, stacklevel=2)
+    return line.get_all_sub_lines()
 
 
 def get_source(line: TrueLine | FakeLine) -> str:
-    """Return the gedcom text equivalent for the line and its sub-lines."""
-    if not line:
-        return ""
-    text = str(line) + "\n"
-    for sub_line in get_all_sub_lines(line):
-        text += str(sub_line) + "\n"
-    return text
+    """/!\\ DEPRECATED /!\\ use the method :py:meth:`Line.get_source` instead.
+
+    Return the gedcom text equivalent for the line and its sub-lines."""
+    warnings.warn("Use the Line.get_source method instead of function in fastgedcom.helpers",
+                  DeprecationWarning, stacklevel=2)
+    return line.get_source()
 
 
 def format_name(name: str) -> str:

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 
 from fastgedcom.base import TrueLine
-from fastgedcom.parser import strict_parse
+from fastgedcom.parser import parse, strict_parse
 
 gedcom_file = Path(__file__).parent / "test_data" / "relatives.ged"
 
@@ -48,6 +48,12 @@ class TestBase(unittest.TestCase):
             TrueLine(2, "CONC", "ence that is split."),
         ])
         self.assertEqual(note_line3.payload_with_cont, note_text3)
+
+    def test_document_to_gedcom(self) -> None:
+        source = "0 HEAD\n1 GEDC\n2 VERS 5.5\n1 CHAR UTF-8\n0 TRLR\n"
+        doc, _ = parse(source.splitlines())
+        output = doc.get_source()
+        self.assertEqual(source, output)
 
 
 if __name__ == '__main__':

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from fastgedcom.base import TrueLine
 from fastgedcom.helpers import (
@@ -22,19 +23,23 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(extract_name_parts("Gatien ... /BOUYER / ***"), ("Gatien ... ***", "BOUYER"))
 
     def test_sub_rec_recursive(self) -> None:
-        surn = TrueLine(2, "SURN", "BOUYER", [])
-        givn = TrueLine(2, "GIVN", "Gatien", [])
-        name = TrueLine(1, "NAME", "Gatien /BOUYER/", [surn, givn])
-        sex = TrueLine(1, "SEX", "M", [])
-        indi = TrueLine(0, "@I1@", "INDI", [name, sex])
-        all_recs = list(get_all_sub_lines(indi))
-        self.assertListEqual(all_recs, [name, surn, givn, sex])
+        with warnings.catch_warnings(record=True) as w:
+            surn = TrueLine(2, "SURN", "BOUYER", [])
+            givn = TrueLine(2, "GIVN", "Gatien", [])
+            name = TrueLine(1, "NAME", "Gatien /BOUYER/", [surn, givn])
+            sex = TrueLine(1, "SEX", "M", [])
+            indi = TrueLine(0, "@I1@", "INDI", [name, sex])
+            all_recs = list(get_all_sub_lines(indi))
+            self.assertListEqual(all_recs, [name, surn, givn, sex])
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
     def test_get_source(self) -> None:
-        header = "0 HEAD\n1 GEDC\n2 VERS 5.5\n2 FORM LINEAGE-LINKED\n1 CHAR UTF-8\n"
-        doc, _ = parse(header.splitlines())
-        self.assertEqual(get_source(doc["HEAD"]), header)
-        self.assertEqual(get_source(doc["@@"]), "")
+        with warnings.catch_warnings(record=True) as w:
+            header = "0 HEAD\n1 GEDC\n2 VERS 5.5\n2 FORM LINEAGE-LINKED\n1 CHAR UTF-8\n"
+            doc, _ = parse(header.splitlines())
+            self.assertEqual(get_source(doc["HEAD"]), header)
+            self.assertEqual(get_source(doc["@@"]), "")
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
 
 if __name__ == '__main__':

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from sys import platform
 
 from fastgedcom.base import TrueLine
-from fastgedcom.helpers import get_all_sub_lines
 from fastgedcom.parser import (
     IS_ANSEL_INSTALLED, CharacterInsteadOfLineWarning, DuplicateXRefWarning,
     EmptyLineWarning, LevelInconsistencyWarning, LevelParsingWarning,
@@ -40,7 +39,7 @@ class TestParser(unittest.TestCase):
         assert indi
         name = indi.get_sub_line_payload("NAME")
         self.assertEqual(name, "éàç /ÉÀÇ/")
-        nb_lines = len(g.records) + sum(1 for r in g for _ in get_all_sub_lines(r))
+        nb_lines = len(g.records) + sum(1 for r in g for _ in r.get_all_sub_lines())
         self.assertEqual(nb_lines, expected_number_of_lines)
 
     def test_parsing_utf8(self) -> None:
@@ -71,7 +70,7 @@ class TestParser(unittest.TestCase):
             name = indi.get_sub_line_payload("NAME")
             ansel_name = b'\xe2e\xe1a\xf0c /\xe2E\xe1A\xf0C/'.decode("gedcom")
             self.assertEqual(name, ansel_name)
-            nb_lines = len(g.records) + sum(1 for r in g for _ in get_all_sub_lines(r))
+            nb_lines = len(g.records) + sum(1 for r in g for _ in r.get_all_sub_lines())
             self.assertEqual(nb_lines, 27)
 
     def test_guess_parsing(self) -> None:


### PR DESCRIPTION
The _fastgedcom.helpers_ modules is a bit of a mess with to many functions of many kinds. The idea is to remove (in the future) `get_all_sub_lines()` and `get_source()` from the _helpers_ module. And what a great feature to directly add those 2 functions to the generic Line class.

Two enhancements:
- _fastgedcom.helpers_ modules is less crowded.
- `get_all_sub_lines()` and `get_source()` functions are more accessible.

Bonus: We should add a `Document.get_source()` method to easy the export back to gedcom files.